### PR TITLE
ci: repo-audit — entry-based madge

### DIFF
--- a/.github/workflows/repo-audit.yml
+++ b/.github/workflows/repo-audit.yml
@@ -47,10 +47,10 @@ jobs:
             | tee reports/depcheck.txt || true
 
           # madge (orphans & cycles)
-          pnpm dlx madge@8.0.0 --extensions ts,tsx --ts-config tsconfig.json --orphans src \
+          pnpm dlx madge@8.0.0 --extensions ts,tsx --ts-config tsconfig.json --orphans src/main.tsx \
             | tee reports/madge-orphans.txt || true
 
-          pnpm dlx madge@8.0.0 --extensions ts,tsx --ts-config tsconfig.json --circular src \
+          pnpm dlx madge@8.0.0 --extensions ts,tsx --ts-config tsconfig.json --circular src/main.tsx \
             | tee reports/madge-cycles.txt || true
 
       - name: Upload reports


### PR DESCRIPTION
Scan from src/main.tsx so only truly unreachable files are flagged.